### PR TITLE
Add 'not_if' blocks to skip steps if wildfly has already been installed.

### DIFF
--- a/wildfly/recipes/add_deploy_user.rb
+++ b/wildfly/recipes/add_deploy_user.rb
@@ -1,4 +1,5 @@
 execute "add user" do
   user "root"
   command '/opt/wildfly/bin/add-user.sh --silent ' + node['wildfly']['deploy_username'] + ' ' + node['wildfly']['deploy_password']
+  # there isn't an obvious way to see if a user already exists or not in wildfly.. so this command may just run and fail.  we'll see.
 end

--- a/wildfly/recipes/default.rb
+++ b/wildfly/recipes/default.rb
@@ -8,21 +8,25 @@ remote_file '/opt/wildfly-' + node['wildfly']['version'] + '.tar.gz' do
   mode 0744
   owner node['wildfly']['user']
   group node['wildfly']['group']
+  not_if { File.exists?('/opt/wildfly')}
 end
 
 execute 'unpack-wildfly' do
   cwd "/opt"
   command "tar -zxf wildfly-" + node['wildfly']['version'] + ".tar.gz"
   action :run
+  not_if { File.exists?('/opt/wildfly')}
 end
 
 execute 'chown-wildfly' do
   cwd '/opt'
   command 'chown -R wildfly:wildfly /opt/wildfly-' + node['wildfly']['version']
+  not_if { File.exists?('/opt/wildfly')}
 end
 
 execute 'rename-directory-remove-version' do
   command 'mv /opt/wildfly-' + node['wildfly']['version'] + ' /opt/wildfly'
+  not_if { File.exists?('/opt/wildfly')}
 end
 
 include_recipe 'wildfly::wildfly_service'

--- a/wildfly/recipes/wildfly_service.rb
+++ b/wildfly/recipes/wildfly_service.rb
@@ -15,18 +15,21 @@ template "/tmp/wildfly-service.sh" do
   backup false
   source "service.sh.erb"
   mode 0755
+
 end
 
 directory 'log-directory' do
   path '/opt/wildfly/standalone/log'
   owner 'wildfly'
   group 'wildfly'
+  not_if { File.exists?('/opt/wildfly/standalone/log')}
 end
 
 directory 'data-directory' do
   path '/opt/wildfly/standalone/data'
   owner 'wildfly'
   group 'wildfly'
+  not_if { File.exists?('/opt/wildfly/standalone/data')}
 end
 
 execute "install wildfly service" do
@@ -34,4 +37,5 @@ execute "install wildfly service" do
   command "sudo sh /tmp/wildfly-service.sh"
   :run
   notifies :start, "service[wildfly]"
+  not_if 'service --status-all | grep -Fq \'wildfly\''
 end


### PR DESCRIPTION
Don't reinstall wildfly on servers that already have it.  The recipes were built assuming each time they were run would be on a fresh server.  This was true until we switched to EBS backed t2.\* instances that preserve state across stop/start.

Use guards as defined here: https://docs.chef.io/chef/resources.html#guards to prevent re-installation of wildfly on servers that have it.
