### PR TITLE
Add a template file for standalone.conf

### DIFF
--- a/wildfly/attributes/default.rb
+++ b/wildfly/attributes/default.rb
@@ -1,4 +1,4 @@
 default['wildfly']['initial_heap_size'] = '64m'
 default['wildfly']['max_heap_size'] = '512m'
-default['wildfly']['max_permgen_space'] = '512m'
+default['wildfly']['max_permgen_space'] = '256m'
 default['wildfly']['console_log_level'] = 'INFO'

--- a/wildfly/attributes/default.rb
+++ b/wildfly/attributes/default.rb
@@ -1,0 +1,4 @@
+default['wildfly']['initial_heap_size'] = '64m'
+default['wildfly']['max_heap_size'] = '512m'
+default['wildfly']['max_permgen_space'] = '512m'
+default['wildfly']['console_log_level'] = 'INFO'

--- a/wildfly/recipes/default.rb
+++ b/wildfly/recipes/default.rb
@@ -29,5 +29,11 @@ execute 'rename-directory-remove-version' do
   not_if { File.exists?('/opt/wildfly')}
 end
 
+template "/opt/wildfly/bin/standalone.conf" do
+  backup false
+  source "standalone.conf.erb"
+  mode 0755
+end
+
 include_recipe 'wildfly::wildfly_service'
 include_recipe 'wildfly::add_deploy_user'

--- a/wildfly/templates/default/standalone.conf.erb
+++ b/wildfly/templates/default/standalone.conf.erb
@@ -1,0 +1,70 @@
+## -*- shell-script -*- ######################################################
+##                                                                          ##
+##  JBoss Bootstrap Script Configuration                                    ##
+##                                                                          ##
+##############################################################################
+
+#
+# This file is optional; it may be removed if not needed.
+#
+
+#
+# Specify the maximum file descriptor limit, use "max" or "maximum" to use
+# the default, as queried by the system.
+#
+# Defaults to "maximum"
+#
+#MAX_FD="maximum"
+
+#
+# Specify the profiler configuration file to load.
+#
+# Default is to not load profiler configuration file.
+#
+#PROFILER=""
+
+#
+# Specify the location of the Java home directory.  If set then $JAVA will
+# be defined to $JAVA_HOME/bin/java, else $JAVA will be "java".
+#
+#JAVA_HOME="/opt/java/jdk"
+
+#
+# Specify the exact Java VM executable to use.
+#
+#JAVA=""
+
+if [ "x$JBOSS_MODULES_SYSTEM_PKGS" = "x" ]; then
+JBOSS_MODULES_SYSTEM_PKGS="org.jboss.byteman"
+fi
+
+# Uncomment the following line to prevent manipulation of JVM options
+# by shell scripts.
+#
+#PRESERVE_JAVA_OPTS=true
+
+#
+# Specify options to pass to the Java VM.
+#
+if [ "x$JAVA_OPTS" = "x" ]; then
+JAVA_OPTS="-Xms512m -Xmx2048m -XX:MaxPermSize=2048m -Djava.net.preferIPv4Stack=true"
+JAVA_OPTS="$JAVA_OPTS -Djboss.modules.system.pkgs=$JBOSS_MODULES_SYSTEM_PKGS -Djava.awt.headless=true"
+else
+echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"
+fi
+
+# Sample JPDA settings for remote socket debugging
+#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
+
+# Sample JPDA settings for shared memory debugging
+#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=jboss"
+
+# Uncomment to not use JBoss Modules lockless mode
+#JAVA_OPTS="$JAVA_OPTS -Djboss.modules.lockless=false"
+
+# Uncomment to gather JBoss Modules metrics
+#JAVA_OPTS="$JAVA_OPTS -Djboss.modules.metrics=true"
+
+# Uncomment this in order to be able to run WildFly on FreeBSD
+# when you get "epoll_create function not implemented" message in dmesg output
+#JAVA_OPTS="$JAVA_OPTS -Djava.nio.channels.spi.SelectorProvider=sun.nio.ch.PollSelectorProvider"

--- a/wildfly/templates/default/standalone.conf.erb
+++ b/wildfly/templates/default/standalone.conf.erb
@@ -47,7 +47,7 @@ fi
 # Specify options to pass to the Java VM.
 #
 if [ "x$JAVA_OPTS" = "x" ]; then
-JAVA_OPTS="-Xms512m -Xmx2048m -XX:MaxPermSize=2048m -Djava.net.preferIPv4Stack=true"
+JAVA_OPTS="-Xms<%= node[:wildfly][:initial_heap_size] %> -Xmx<%= node[:wildfly][:max_heap_size] %> -XX:MaxPermSize=<%= node[:wildfly][:max_permgen_space] %> -Djava.net.preferIPv4Stack=true"
 JAVA_OPTS="$JAVA_OPTS -Djboss.modules.system.pkgs=$JBOSS_MODULES_SYSTEM_PKGS -Djava.awt.headless=true"
 else
 echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"


### PR DESCRIPTION
- in this file contains parameters to set initial & max heap size as well as max permgen space
- these values will be passed in as parameters from stack JSON
- going to try:
  - initial heap 512m
  - max heap 3072m
  - max permgen 2048m

This should help with, but not totally solve, some memory issues that crop up from time to time.

Specifically...
- the god tools webapp contractors killed the stage server with a blast of large requests that certainly filled the heap which maxed at 512m
- repeated deployments will max out permgen space.  this just buys a little more time until a new (Docker!) solution is implemented
