### PR TITLE
Add property "s3BucketName" to god tools properties file

### DIFF
--- a/godtools_api/templates/default/godtools_api_properties.xml.erb
+++ b/godtools_api/templates/default/godtools_api_properties.xml.erb
@@ -19,6 +19,8 @@
     <entry key="memcachedPort"><%= node['godtools']['memcached_port'] %></entry>
     <entry key="googleApiKey"><%= node['godtools']['google_api_key'] %></entry>
 
+    <entry key="s3BucketName"><%= node['godtools']['s3_bucket_name'] %></entry>
+
     <entry key="mode">debug</entry>
 
 </properties>


### PR DESCRIPTION
Used to specify stage or production bucket at runtime
